### PR TITLE
Update projects to Avalonia 12.0.0 and stabilize release packaging

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <Company>Wiesław Šoltés</Company>
     <Copyright>Copyright © Wiesław Šoltés 2025</Copyright>
     <PackageProjectUrl>https://github.com/wieslawsoltes/Lottie</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <PropertyGroup>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -15,4 +16,7 @@
     <SkiaSharpVersion>3.119.3-preview.1.1</SkiaSharpVersion>
     <TmdsDBusProtocolVersion>0.92.0</TmdsDBusProtocolVersion>
   </PropertyGroup>
+  <ItemGroup Condition="'$(IsPackable)' == 'True'">
+    <None Include="$(MSBuildThisFileDirectory)README.md" Link="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>12.0.0</VersionPrefix>
-    <VersionSuffix>rc2</VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Copyright>Copyright © Wiesław Šoltés 2025</Copyright>
@@ -12,7 +11,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <AvaloniaVersion>12.0.0-rc2</AvaloniaVersion>
+    <AvaloniaVersion>12.0.0</AvaloniaVersion>
     <SkiaSharpVersion>3.119.3-preview.1.1</SkiaSharpVersion>
+    <TmdsDBusProtocolVersion>0.92.0</TmdsDBusProtocolVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup Condition="'$(IsPackable)' == 'True'">
+    <!-- Avalonia.Skia 12.0.0 currently resolves to prerelease SkiaSharp packages. -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/samples/AnimationControlDemo/AnimationControlDemo.csproj
+++ b/samples/AnimationControlDemo/AnimationControlDemo.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="$(TmdsDBusProtocolVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/AnimationControl/AnimationControl.csproj" />

--- a/samples/CompositionAnimatedControlDemo/CompositionAnimatedControlDemo.csproj
+++ b/samples/CompositionAnimatedControlDemo/CompositionAnimatedControlDemo.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Skia" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Box2D.NetStandard" Version="2.4.7-alpha" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="$(TmdsDBusProtocolVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../../src/CompositionAnimatedControl/CompositionAnimatedControl.csproj" />

--- a/samples/EffectsDemo/EffectsDemo.csproj
+++ b/samples/EffectsDemo/EffectsDemo.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)"/>
     <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="$(TmdsDBusProtocolVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/EffectsDemo/Old.cs
+++ b/samples/EffectsDemo/Old.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Numerics;
 using Avalonia;
-using Avalonia.Controls.Shapes;
-using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering.Composition;
 using Avalonia.Skia;
@@ -12,10 +10,6 @@ namespace EffectsDemo;
 
 internal class DrawCompositionCustomVisualHandler
 {
-    private bool _running;
-    private Stretch? _stretch;
-    private StretchDirection? _stretchDirection;
-    private Size? _size;
     private readonly object _sync = new();
     private SKPaint? _paint;
     private SKShader? _shader;

--- a/samples/LottieDemo.Desktop/LottieDemo.Desktop.csproj
+++ b/samples/LottieDemo.Desktop/LottieDemo.Desktop.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="$(TmdsDBusProtocolVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\LottieDemo\LottieDemo.csproj" />

--- a/samples/LottieToSvg/LottieToSvg.csproj
+++ b/samples/LottieToSvg/LottieToSvg.csproj
@@ -17,5 +17,6 @@
     <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
     <PackageReference Include="SkiaSharp.Skottie" Version="$(SkiaSharpVersion)" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="$(TmdsDBusProtocolVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Update projects to Avalonia 12.0.0 and stabilize release packaging

## Summary

This PR moves the repository from the Avalonia `12.0.0-rc2` lane to the stable `12.0.0` release and aligns the project/package versioning with that stable release.

It also removes restore noise from the desktop sample projects by overriding the vulnerable transitive `Tmds.DBus.Protocol` dependency to `0.92.0`, adds package readme metadata for the packable libraries, and keeps `dotnet pack` clean in the current Avalonia 12.0.0 package graph.

## Changes

### Versioning and package updates

- Remove the repository-wide `VersionSuffix` so local package output is `12.0.0`.
- Update `AvaloniaVersion` from `12.0.0-rc2` to `12.0.0`.
- Introduce a shared `TmdsDBusProtocolVersion` property set to `0.92.0`.
- Add explicit `Tmds.DBus.Protocol` references in desktop sample projects to override the vulnerable transitive `0.90.3` dependency pulled by `Avalonia.Desktop`.

### Release packaging cleanup

- Add `PackageReadmeFile` so the NuGet packages include the repository `README.md`.
- Pack the root `README.md` into packable projects through `Directory.Build.props`.
- Add `Directory.Build.targets` to suppress `NU5104` for packable projects.

### Why `NU5104` is suppressed

Avalonia `12.0.0` currently resolves `Avalonia.Skia` through prerelease `SkiaSharp` packages (`3.119.3-preview.1.1`).

This repository exposes SkiaSharp types in its public API, so forcing a lower stable SkiaSharp version causes restore downgrades and breaks the build. In the current upstream package graph, the practical fix is to keep the resolved SkiaSharp version aligned with Avalonia and suppress the pack warning that would otherwise mark those dependencies as a local packaging issue.

### Small cleanup

- Remove dead fields and now-unused imports from `samples/EffectsDemo/Old.cs`.

## Diagnostics note

The repository did not contain `Avalonia.Diagnostics`, `AvaloniaUI.DiagnosticsSupport`, or existing developer tools wiring to migrate. Because of that, there was nothing to switch to `ProDiagnostics` in this branch.

## Commit breakdown

1. `chore: update Avalonia packages to 12.0.0`
2. `chore: clean up package release metadata`
3. `chore: remove dead EffectsDemo code`

## Validation

Executed successfully:

- `dotnet test Avalonia.Skia.Lottie.sln -c Release`
- `dotnet pack Avalonia.Skia.Lottie.sln -c Release --no-build -o artifacts/packages`

Produced packages:

- `artifacts/packages/AnimationControl.12.0.0.nupkg`
- `artifacts/packages/CompositionAnimatedControl.12.0.0.nupkg`
- `artifacts/packages/Lottie.12.0.0.nupkg`
- `artifacts/packages/ShaderAnimatedControl.12.0.0.nupkg`
